### PR TITLE
Replace Namespace token to support packaging

### DIFF
--- a/force-app/main/default/classes/GGW_ApplicationCtrl.cls
+++ b/force-app/main/default/classes/GGW_ApplicationCtrl.cls
@@ -392,7 +392,7 @@ public with sharing class GGW_ApplicationCtrl {
         Id sectionId = s; 
         String objName = sectionId.getsobjecttype()+'';
         System.debug('### Obj: '+objName+' ID: '+s);
-        if(objName.equals('%%%NAMESPACE%%%GGW_Section__c')){ // Create new selected item junction for section
+        if(objName.equals('%%%NAMESPACED_ORG%%%GGW_Section__c')){ // Create new selected item junction for section
             res = true;
         }
         return res;

--- a/force-app/main/default/objects/GGW_Grant_Application__c/fields/Application_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/GGW_Grant_Application__c/fields/Application_Name__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Application_Name__c</fullName>
     <externalId>false</externalId>
-    <formula>HYPERLINK(&quot;/lightning/n/%%%NAMESPACE%%%GGW_Grant_Editor?c__uictx=page&amp;c__recordId=&quot; &amp; Id, Name, &quot;_self&quot;)</formula>
+    <formula>HYPERLINK(&quot;/lightning/n/%%%NAMESPACED_ORG%%%GGW_Grant_Editor?c__uictx=page&amp;c__recordId=&quot; &amp; Id, Name, &quot;_self&quot;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Application Name</label>
     <required>false</required>


### PR DESCRIPTION

# Critical Changes

Replace CCI Namespace token: %%%NAMESPACED_ORG%%%
This token is meant to be used for the Packaging Org.  CCI documentation for [Namespace injection](https://cumulusci.readthedocs.io/en/stable/unpackaged.html#:~:text=%25%25%25NAMESPACED_ORG%25%25%25).
# Changes

# Issues Closed
#165 